### PR TITLE
Split acme package into client and resources packages.

### DIFF
--- a/acme/client/http.go
+++ b/acme/client/http.go
@@ -1,4 +1,4 @@
-package acme
+package client
 
 import (
 	"encoding/json"

--- a/acme/constants.go
+++ b/acme/constants.go
@@ -1,0 +1,15 @@
+// Package acme provides ACME protocol constants.
+package acme
+
+const (
+	// See https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.1.1
+	// The ACME directory key for the newNonce endpoint
+	NEW_NONCE_ENDPOINT = "newNonce"
+	// The ACME directory key for the newAccount endpoint.
+	NEW_ACCOUNT_ENDPOINT = "newAccount"
+	// The ACME directory key for the newOrder endpoint.
+	NEW_ORDER_ENDPOINT = "newOrder"
+	// The HTTP response header used by ACME to communicate a fresh nonce. See
+	// https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.6.5.1
+	REPLAY_NONCE_HEADER = "Replay-Nonce"
+)

--- a/acme/resources/account.go
+++ b/acme/resources/account.go
@@ -1,4 +1,6 @@
-package acme
+// Package resources provides types for representing and interacting with ACME
+// protocol resources.
+package resources
 
 import (
 	"crypto/ecdsa"

--- a/acme/resources/authorization.go
+++ b/acme/resources/authorization.go
@@ -1,4 +1,4 @@
-package acme
+package resources
 
 // The Identifier resource represents a subject identifier that can be included
 // in a certificate.

--- a/acme/resources/challenge.go
+++ b/acme/resources/challenge.go
@@ -1,4 +1,4 @@
-package acme
+package resources
 
 // The ACME Challenge resource represents an action that the client must take to
 // authorize a given account for a specific identifier in order to issue

--- a/acme/resources/order.go
+++ b/acme/resources/order.go
@@ -1,4 +1,4 @@
-package acme
+package resources
 
 // The Order resource represents a collection of identifiers that an account
 // wishes to create a Certificate for.

--- a/cmd/acmeshell/main.go
+++ b/cmd/acmeshell/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/abiosoft/readline"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 	"github.com/cpu/acmeshell/challtestsrv"
 	"github.com/cpu/acmeshell/cmd"
 	acmeshell "github.com/cpu/acmeshell/shell"
@@ -103,7 +103,7 @@ func main() {
 	go challSrv.Run()
 
 	// Create an ACME client
-	client, err := acme.NewClient(acme.ClientConfig{
+	client, err := acmeclient.NewClient(acmeclient.ClientConfig{
 		DirectoryURL: *directory,
 		CACert:       *caCert,
 		AutoRegister: *autoRegister,

--- a/shell/accounts.go
+++ b/shell/accounts.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type accountsCmd struct {
@@ -35,7 +35,7 @@ var Accounts accountsCmd = accountsCmd{
 	},
 }
 
-func (a accountsCmd) New(client *acme.Client) *ishell.Cmd {
+func (a accountsCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return Accounts.cmd
 }
 

--- a/shell/challSrv.go
+++ b/shell/challSrv.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type challSrvOptions struct {
@@ -29,7 +29,7 @@ var challSrv challSrvCmd = challSrvCmd{
 	},
 }
 
-func (c challSrvCmd) New(client *acme.Client) *ishell.Cmd {
+func (c challSrvCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return challSrv.cmd
 }
 

--- a/shell/common.go
+++ b/shell/common.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 	"github.com/cpu/acmeshell/challtestsrv"
 )
 
@@ -18,7 +18,7 @@ const (
 )
 
 type AcmeCmd interface {
-	New(client *acme.Client) *ishell.Cmd
+	New(client *acmeclient.Client) *ishell.Cmd
 }
 
 var Commands []AcmeCmd = []AcmeCmd{
@@ -49,18 +49,18 @@ var Commands []AcmeCmd = []AcmeCmd{
 	challSrv,
 }
 
-func getClient(c *ishell.Context) *acme.Client {
+func getClient(c *ishell.Context) *acmeclient.Client {
 	if c.Get(ClientKey) == nil {
 		panic(fmt.Sprintf("nil %q value in ishell.Context", ClientKey))
 	}
 
 	rawClient := c.Get(ClientKey)
 	switch c := rawClient.(type) {
-	case *acme.Client:
+	case *acmeclient.Client:
 		return c
 	}
 
-	panic(fmt.Sprintf("%q value in ishell.Context was not an *acme.Client", ClientKey))
+	panic(fmt.Sprintf("%q value in ishell.Context was not an *acmeclient.Client", ClientKey))
 }
 
 func getChallSrv(c *ishell.Context) *challtestsrv.ChallSrv {

--- a/shell/csr.go
+++ b/shell/csr.go
@@ -14,7 +14,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type csrCmd struct {
@@ -37,7 +38,7 @@ var CSR csrCmd = csrCmd{
 	},
 }
 
-func (c csrCmd) New(client *acme.Client) *ishell.Cmd {
+func (c csrCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return CSR.cmd
 }
 
@@ -65,7 +66,7 @@ func csrHandler(c *ishell.Context) {
 
 	client := getClient(c)
 
-	var order *acme.Order
+	var order *resources.Order
 	if len(csrFlags.Args()) == 0 && *identifiersArg == "" {
 		orders := client.ActiveAccount.Orders
 		if len(orders) == 0 {
@@ -149,7 +150,7 @@ func csrHandler(c *ishell.Context) {
 	}
 }
 
-func csr(client *acme.Client, opts csrOptions, names []string) (string, string, error) {
+func csr(client *acmeclient.Client, opts csrOptions, names []string) (string, string, error) {
 	if len(names) == 0 {
 		return "", "", fmt.Errorf("no names specified")
 	}
@@ -190,10 +191,10 @@ func csr(client *acme.Client, opts csrOptions, names []string) (string, string, 
 	return base64.RawURLEncoding.EncodeToString(csrBytes), string(pemBytes), nil
 }
 
-func getOrderObject(client *acme.Client, orderURL string, opts *acme.HTTPOptions) (*acme.Order, error) {
-	var order acme.Order
+func getOrderObject(client *acmeclient.Client, orderURL string, opts *acmeclient.HTTPOptions) (*resources.Order, error) {
+	var order resources.Order
 	if opts == nil {
-		opts = &acme.HTTPOptions{
+		opts = &acmeclient.HTTPOptions{
 			PrintHeaders:  false,
 			PrintStatus:   false,
 			PrintResponse: false,

--- a/shell/echo.go
+++ b/shell/echo.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type echoCmd struct {
@@ -20,7 +20,7 @@ var echo echoCmd = echoCmd{
 	},
 }
 
-func (e echoCmd) New(client *acme.Client) *ishell.Cmd {
+func (e echoCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return echo.cmd
 }
 

--- a/shell/finalize.go
+++ b/shell/finalize.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type finalizeOptions struct {
@@ -32,7 +33,7 @@ var finalize finalizeCmd = finalizeCmd{
 	},
 }
 
-func (fc finalizeCmd) New(client *acme.Client) *ishell.Cmd {
+func (fc finalizeCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return finalize.cmd
 }
 
@@ -66,7 +67,7 @@ func finalizeHandler(c *ishell.Context) {
 
 	var orderURL string
 	if len(finalizeFlags.Args()) == 0 {
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)
@@ -127,7 +128,7 @@ func finalizeHandler(c *ishell.Context) {
 	}
 	finalizeRequestJSON, _ := json.Marshal(&finalizeRequest)
 
-	signedBody, err := client.ActiveAccount.Sign(order.Finalize, finalizeRequestJSON, acme.SignOptions{
+	signedBody, err := client.ActiveAccount.Sign(order.Finalize, finalizeRequestJSON, resources.SignOptions{
 		NonceSource:    client,
 		PrintJWS:       false,
 		PrintJWSObject: false,
@@ -138,7 +139,7 @@ func finalizeHandler(c *ishell.Context) {
 		return
 	}
 
-	postOpts := &acme.HTTPOptions{
+	postOpts := &acmeclient.HTTPOptions{
 		PrintHeaders:  false,
 		PrintStatus:   false,
 		PrintResponse: false,
@@ -157,7 +158,7 @@ func finalizeHandler(c *ishell.Context) {
 	c.Printf("order %q finalization requested\n", order.ID)
 }
 
-func pickOrder(c *ishell.Context) (*acme.Order, error) {
+func pickOrder(c *ishell.Context) (*resources.Order, error) {
 	client := getClient(c)
 	if len(client.ActiveAccount.Orders) == 0 {
 		return nil, fmt.Errorf("active account has no orders")

--- a/shell/get.go
+++ b/shell/get.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 	"github.com/cpu/acmeshell/cmd"
 )
 
@@ -16,7 +16,7 @@ type getCmd struct {
 }
 
 type getOptions struct {
-	acme.HTTPOptions
+	acmeclient.HTTPOptions
 }
 
 var get getCmd = getCmd{
@@ -49,7 +49,7 @@ var get getCmd = getCmd{
 	},
 }
 
-func (g getCmd) New(client *acme.Client) *ishell.Cmd {
+func (g getCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	// Get the directory from the client to use when constructing shell commands
 	dirMap, err := client.Directory()
 	cmd.FailOnError(err, "Unable to get ACME server directory")

--- a/shell/getAcct.go
+++ b/shell/getAcct.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type getAccountOptions struct {
-	acme.HTTPOptions
+	acmeclient.HTTPOptions
 }
 
 type getAccountCmd struct {
@@ -27,7 +29,7 @@ var getAccount getAccountCmd = getAccountCmd{
 	},
 }
 
-func (g getAccountCmd) New(client *acme.Client) *ishell.Cmd {
+func (g getAccountCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return getAccount.cmd
 }
 
@@ -62,7 +64,7 @@ func getAccountHandler(c *ishell.Context) {
 		return
 	}
 
-	signedBody, err := client.ActiveAccount.Sign(newAcctURL, reqBody, acme.SignOptions{
+	signedBody, err := client.ActiveAccount.Sign(newAcctURL, reqBody, resources.SignOptions{
 		EmbedKey:    true,
 		NonceSource: client,
 	})

--- a/shell/getAuthz.go
+++ b/shell/getAuthz.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type getAuthzOptions struct {
-	acme.HTTPOptions
+	acmeclient.HTTPOptions
 	orderIndex int
 	identifier string
 }
@@ -28,7 +29,7 @@ var getAuthz getAuthzCmd = getAuthzCmd{
 	},
 }
 
-func (g getAuthzCmd) New(client *acme.Client) *ishell.Cmd {
+func (g getAuthzCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return getAuthz.cmd
 }
 
@@ -58,7 +59,7 @@ func getAuthzHandler(c *ishell.Context) {
 
 	var authzURL string
 	if len(getAuthzFlags.Args()) == 0 {
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)
@@ -73,7 +74,7 @@ func getAuthzHandler(c *ishell.Context) {
 				return
 			}
 		}
-		var authz *acme.Authorization
+		var authz *resources.Authorization
 		if opts.identifier != "" {
 			for _, authURL := range order.Authorizations {
 				a, err := getAuthzObject(client, authURL, nil)

--- a/shell/getCert.go
+++ b/shell/getCert.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type getCertOptions struct {
@@ -31,7 +32,7 @@ var getCert getCertCmd = getCertCmd{
 	},
 }
 
-func (gc getCertCmd) New(client *acme.Client) *ishell.Cmd {
+func (gc getCertCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return getCert.cmd
 }
 
@@ -59,7 +60,7 @@ func getCertHandler(c *ishell.Context) {
 
 	var orderURL string
 	if len(getCertFlags.Args()) == 0 {
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)
@@ -104,7 +105,7 @@ func getCertHandler(c *ishell.Context) {
 		return
 	}
 
-	httpOpts := &acme.HTTPOptions{
+	httpOpts := &acmeclient.HTTPOptions{
 		PrintHeaders:  false,
 		PrintStatus:   false,
 		PrintResponse: false,

--- a/shell/getChall.go
+++ b/shell/getChall.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type getChallOptions struct {
-	acme.HTTPOptions
+	acmeclient.HTTPOptions
 	orderIndex int
 	identifier string
 	challType  string
@@ -29,7 +30,7 @@ var getChall getChallCmd = getChallCmd{
 	},
 }
 
-func (g getChallCmd) New(client *acme.Client) *ishell.Cmd {
+func (g getChallCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return getChall.cmd
 }
 
@@ -55,7 +56,7 @@ func getChallHandler(c *ishell.Context) {
 
 	var challURL string
 	if len(getChallFlags.Args()) == 0 {
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)
@@ -70,7 +71,7 @@ func getChallHandler(c *ishell.Context) {
 				return
 			}
 		}
-		var authz *acme.Authorization
+		var authz *resources.Authorization
 		if opts.identifier != "" {
 			for _, authURL := range order.Authorizations {
 				a, err := getAuthzObject(client, authURL, nil)
@@ -95,7 +96,7 @@ func getChallHandler(c *ishell.Context) {
 			}
 		}
 
-		var chall *acme.Challenge
+		var chall *resources.Challenge
 		if opts.challType != "" {
 			for _, c := range authz.Challenges {
 				if c.Type == opts.challType {

--- a/shell/getOrder.go
+++ b/shell/getOrder.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type getOrderOptions struct {
-	acme.HTTPOptions
+	acmeclient.HTTPOptions
 	orderIndex int
 }
 
@@ -27,7 +28,7 @@ var getOrder getOrderCmd = getOrderCmd{
 	},
 }
 
-func (g getOrderCmd) New(client *acme.Client) *ishell.Cmd {
+func (g getOrderCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return getOrder.cmd
 }
 
@@ -51,7 +52,7 @@ func getOrderHandler(c *ishell.Context) {
 
 	var orderURL string
 	if len(getOrderFlags.Args()) == 0 {
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)

--- a/shell/keys.go
+++ b/shell/keys.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 	jose "gopkg.in/square/go-jose.v2"
 )
 
@@ -39,7 +39,7 @@ var viewKey viewKeyCmd = viewKeyCmd{
 	},
 }
 
-func (vk viewKeyCmd) New(client *acme.Client) *ishell.Cmd {
+func (vk viewKeyCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return viewKey.cmd
 }
 

--- a/shell/loadAccount.go
+++ b/shell/loadAccount.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type loadAccountCmd struct {
@@ -26,7 +27,7 @@ var LoadAccount loadAccountCmd = loadAccountCmd{
 	},
 }
 
-func (a loadAccountCmd) New(client *acme.Client) *ishell.Cmd {
+func (a loadAccountCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return LoadAccount.cmd
 }
 
@@ -51,7 +52,7 @@ func loadAccountHandler(c *ishell.Context) {
 	argument := strings.TrimSpace(loadAccountFlags.Arg(0))
 	client := getClient(c)
 
-	acct, err := acme.RestoreAccount(argument)
+	acct, err := resources.RestoreAccount(argument)
 	if err != nil {
 		c.Printf("loadAccount: error restoring account from %q : %s\n",
 			argument, err)

--- a/shell/loadKey.go
+++ b/shell/loadKey.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type loadKeyCmd struct {
@@ -29,7 +29,7 @@ var loadKey loadKeyCmd = loadKeyCmd{
 	},
 }
 
-func (lk loadKeyCmd) New(client *acme.Client) *ishell.Cmd {
+func (lk loadKeyCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return loadKey.cmd
 }
 

--- a/shell/newAccount.go
+++ b/shell/newAccount.go
@@ -6,7 +6,8 @@ import (
 
 	"crypto/ecdsa"
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type newAccountCmd struct {
@@ -14,7 +15,7 @@ type newAccountCmd struct {
 }
 
 type newAccountOptions struct {
-	acme.HTTPPostOptions
+	acmeclient.HTTPPostOptions
 	contacts string
 	switchTo bool
 	jsonPath string
@@ -31,7 +32,7 @@ var NewAccount newAccountCmd = newAccountCmd{
 	},
 }
 
-func (a newAccountCmd) New(client *acme.Client) *ishell.Cmd {
+func (a newAccountCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return NewAccount.cmd
 }
 
@@ -82,7 +83,7 @@ func newAccountHandler(c *ishell.Context) {
 			acctKey = key
 		}
 	}
-	acct, err := acme.NewAccount(emails, acctKey)
+	acct, err := resources.NewAccount(emails, acctKey)
 	if err != nil {
 		c.Printf("newAccount: error creating new account object: %s\n", err)
 		return
@@ -94,7 +95,7 @@ func newAccountHandler(c *ishell.Context) {
 		c.Printf("newAccount: error creating new account with ACME server: %s\n", err)
 		return
 	}
-	// if opts.keyID was empty then acme.NewAccount got a nil key argument and
+	// if opts.keyID was empty then resources.NewAccount got a nil key argument and
 	// generated a new key on the fly. We need to save that key
 	if opts.keyID == "" {
 		client.Keys[acct.ID] = acct.PrivateKey
@@ -106,7 +107,7 @@ func newAccountHandler(c *ishell.Context) {
 	client.Accounts = append(client.Accounts, acct)
 
 	if opts.jsonPath != "" {
-		err := acme.SaveAccount(opts.jsonPath, acct)
+		err := resources.SaveAccount(opts.jsonPath, acct)
 		if err != nil {
 			c.Printf("error saving account to %q : %s\n", opts.jsonPath, err)
 		}

--- a/shell/newKey.go
+++ b/shell/newKey.go
@@ -15,7 +15,7 @@ import (
 	"crypto/x509"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type newKeyCmd struct {
@@ -39,7 +39,7 @@ var newKey newKeyCmd = newKeyCmd{
 	},
 }
 
-func (nk newKeyCmd) New(client *acme.Client) *ishell.Cmd {
+func (nk newKeyCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return newKey.cmd
 }
 

--- a/shell/newOrder.go
+++ b/shell/newOrder.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type newOrderCmd struct {
@@ -21,26 +22,26 @@ var NewOrder newOrderCmd = newOrderCmd{
 	},
 }
 
-func (a newOrderCmd) New(client *acme.Client) *ishell.Cmd {
+func (a newOrderCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return NewOrder.cmd
 }
 
-func createOrder(fqdns []string, c *ishell.Context, opts *acme.HTTPPostOptions) {
-	var idents []acme.Identifier
+func createOrder(fqdns []string, c *ishell.Context, opts *acmeclient.HTTPPostOptions) {
+	var idents []resources.Identifier
 	// Convert the fqdns to DNS identifiers
 	for _, ident := range fqdns {
 		val := strings.TrimSpace(ident)
 		if val == "" {
 			continue
 		}
-		idents = append(idents, acme.Identifier{
+		idents = append(idents, resources.Identifier{
 			Type:  "dns",
 			Value: val,
 		})
 	}
 
 	client := getClient(c)
-	orderRequest := &acme.Order{
+	orderRequest := &resources.Order{
 		Identifiers: idents,
 	}
 	_, err := client.CreateOrder(orderRequest, opts)
@@ -63,7 +64,7 @@ func newOrderHandler(c *ishell.Context) {
 	newOrderFlags := flag.NewFlagSet("newOrder", flag.ContinueOnError)
 	identifiersArg := newOrderFlags.String("identifiers", "", "Comma separated list of DNS identifiers")
 
-	httpOpts := &acme.HTTPPostOptions{}
+	httpOpts := &acmeclient.HTTPPostOptions{}
 
 	newOrderFlags.BoolVar(&httpOpts.PrintHeaders, "headers", false, "Print HTTP response headers")
 	newOrderFlags.BoolVar(&httpOpts.PrintStatus, "status", true, "Print HTTP response status code")

--- a/shell/orders.go
+++ b/shell/orders.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type ordersCmd struct {
@@ -27,7 +27,7 @@ var Orders ordersCmd = ordersCmd{
 	},
 }
 
-func (a ordersCmd) New(client *acme.Client) *ishell.Cmd {
+func (a ordersCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return Orders.cmd
 }
 
@@ -63,7 +63,7 @@ func ordersHandler(c *ishell.Context) {
 		for i, o := range orders {
 			// Use a hardcoded HTTPOptions because this is a background operation and
 			// we never want to print headers/status
-			_, err := client.UpdateOrder(o, &acme.HTTPOptions{
+			_, err := client.UpdateOrder(o, &acmeclient.HTTPOptions{
 				PrintHeaders: false,
 				PrintStatus:  false,
 			})

--- a/shell/poll.go
+++ b/shell/poll.go
@@ -7,7 +7,8 @@ import (
 	"time"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type pollCmd struct {
@@ -31,7 +32,7 @@ var poll pollCmd = pollCmd{
 	},
 }
 
-func (a pollCmd) New(client *acme.Client) *ishell.Cmd {
+func (a pollCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return poll.cmd
 }
 
@@ -60,7 +61,7 @@ func pollHandler(c *ishell.Context) {
 			c.Printf("poll: the active account has no orders\n")
 			return
 		}
-		var order *acme.Order
+		var order *resources.Order
 		if opts.orderIndex >= 0 && opts.orderIndex < len(client.ActiveAccount.Orders) {
 			orderURL := client.ActiveAccount.Orders[opts.orderIndex]
 			order, err = getOrderObject(client, orderURL, nil)

--- a/shell/post.go
+++ b/shell/post.go
@@ -7,7 +7,8 @@ import (
 	"sync"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 	"github.com/cpu/acmeshell/cmd"
 )
 
@@ -17,8 +18,8 @@ type postCmd struct {
 }
 
 type postOptions struct {
-	acme.HTTPOptions
-	acme.SignOptions
+	acmeclient.HTTPOptions
+	resources.SignOptions
 	postBody     string
 	templateBody bool
 	sign         bool
@@ -56,7 +57,7 @@ var Post postCmd = postCmd{
 	},
 }
 
-func (g postCmd) New(client *acme.Client) *ishell.Cmd {
+func (g postCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	// Get the directory from the client to use when constructing shell commands
 	dirMap, err := client.Directory()
 	cmd.FailOnError(err, "Unable to get ACME server directory")
@@ -84,7 +85,7 @@ func postURL(opts postOptions, targetURL string, c *ishell.Context) {
 
 	postBody := []byte(opts.postBody)
 	if opts.sign {
-		signedBody, err := account.Sign(targetURL, postBody, acme.SignOptions{
+		signedBody, err := account.Sign(targetURL, postBody, resources.SignOptions{
 			NonceSource:    client,
 			PrintJWS:       opts.PrintJWS,
 			PrintJWSObject: opts.PrintJWSObject,

--- a/shell/rollover.go
+++ b/shell/rollover.go
@@ -10,11 +10,12 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type keyRolloverOptions struct {
-	acme.HTTPPostOptions
+	acmeclient.HTTPPostOptions
 	printInnerJWS     bool
 	printInnerJWSBody bool
 	keyID             string
@@ -34,7 +35,7 @@ var keyRollover keyRolloverCmd = keyRolloverCmd{
 	},
 }
 
-func (kr keyRolloverCmd) New(client *acme.Client) *ishell.Cmd {
+func (kr keyRolloverCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return keyRollover.cmd
 }
 
@@ -120,7 +121,7 @@ func rolloverHandler(c *ishell.Context) {
 		return
 	}
 
-	innerSignOpts := acme.SignOptions{
+	innerSignOpts := resources.SignOptions{
 		NonceSource:    client,
 		Key:            newKey,
 		EmbedKey:       true,
@@ -139,7 +140,7 @@ func rolloverHandler(c *ishell.Context) {
 		c.Printf("inner JWS:\n%s\n", string(innerJWS))
 	}
 
-	outerJWS, err := account.Sign(targetURL, innerJWS, acme.SignOptions{
+	outerJWS, err := account.Sign(targetURL, innerJWS, resources.SignOptions{
 		NonceSource:    client,
 		PrintJWS:       false,
 		PrintJWSObject: false,

--- a/shell/sign.go
+++ b/shell/sign.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
+	"github.com/cpu/acmeshell/acme/resources"
 )
 
 type signCmd struct {
@@ -13,7 +14,7 @@ type signCmd struct {
 }
 
 type signCmdOptions struct {
-	acme.SignOptions
+	resources.SignOptions
 	embedKey bool
 	data     []byte
 	keyID    string
@@ -28,7 +29,7 @@ var sign signCmd = signCmd{
 	},
 }
 
-func (s signCmd) New(client *acme.Client) *ishell.Cmd {
+func (s signCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return s.cmd
 }
 
@@ -41,7 +42,7 @@ func signData(opts signCmdOptions, targetURL string, c *ishell.Context) {
 		return
 	}
 
-	signOpts := acme.SignOptions{
+	signOpts := resources.SignOptions{
 		NonceSource:    client,
 		EmbedKey:       opts.embedKey,
 		PrintJWS:       opts.PrintJWS,

--- a/shell/switchAccount.go
+++ b/shell/switchAccount.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/abiosoft/ishell"
-	"github.com/cpu/acmeshell/acme"
+	acmeclient "github.com/cpu/acmeshell/acme/client"
 )
 
 type switchAccountCmd struct {
@@ -23,7 +23,7 @@ var SwitchAccount switchAccountCmd = switchAccountCmd{
 	},
 }
 
-func (a switchAccountCmd) New(client *acme.Client) *ishell.Cmd {
+func (a switchAccountCmd) New(client *acmeclient.Client) *ishell.Cmd {
 	return SwitchAccount.cmd
 }
 


### PR DESCRIPTION
The top-level acme package can be reserved for the few protocol constants we reference. The client package contains the ACME client implementation used to create resources with the ACME server. The resources package contains types for all of the ACME resources the client creates and interacts with.