### PR TITLE
Support Pebble -strict/POST-as-GET

### DIFF
--- a/acme/client/directory.go
+++ b/acme/client/directory.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"encoding/json"
+	"log"
+)
+
+func (c *Client) getDirectory() (map[string]interface{}, error) {
+	url := c.DirectoryURL.String()
+
+	resp, err := c.net.GetURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var directory map[string]interface{}
+	err = json.Unmarshal(resp.RespBody, &directory)
+	if err != nil {
+		return nil, err
+	}
+
+	return directory, nil
+}
+
+// Directory fetches the ACME Directory resource from the ACME server and
+// returns it deserialized as a map.
+//
+// See
+// https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.1.1
+func (c *Client) Directory() (map[string]interface{}, error) {
+	if c.directory == nil {
+		if err := c.UpdateDirectory(); err != nil {
+			return nil, err
+		}
+	}
+
+	return c.directory, nil
+}
+
+// UpdateDirectory updates the Client's cached directory used when referencing
+// the endpoints for updating nonces, creating accounts, and creating orders.
+//
+// TODO(@cpu): I don't think it makes sense for both Directory and
+// UpdateDirectory to be exported/defined on the client.
+func (c *Client) UpdateDirectory() error {
+	newDir, err := c.getDirectory()
+	if err != nil {
+		return err
+	}
+
+	c.directory = newDir
+	log.Printf("Updated directory")
+	return nil
+}
+
+// GetEndpintURL gets a URL for a specific ACME endpoint URL by first fetching
+// the ACME server's directory and then checking that directory resource for the
+// a key with the given name. If the key is found its value is returned along
+// with a true bool. If the key is not found an empty string is returned with
+// a false bool.
+func (c *Client) GetEndpointURL(name string) (string, bool) {
+	dir, err := c.Directory()
+	if err != nil {
+		return "", false
+	}
+	rawURL, ok := dir[name]
+	if !ok {
+		return "", false
+	}
+	switch v := rawURL.(type) {
+	case string:
+		if v == "" {
+			return "", false
+		}
+		return v, true
+	}
+	return "", false
+}

--- a/acme/client/http.go
+++ b/acme/client/http.go
@@ -36,3 +36,13 @@ func (c *Client) PostURL(url string, body []byte) (*net.NetResponse, error) {
 	}
 	return c.handleRequest(req)
 }
+
+func (c *Client) PostAsGetURL(url string) (*net.NetResponse, error) {
+	// Sign the POST-as-GET body
+	signResult, err := c.Sign(url, []byte(""), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.PostURL(url, signResult.SerializedJWS)
+}

--- a/acme/client/nonce.go
+++ b/acme/client/nonce.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/cpu/acmeshell/acme"
+)
+
+// Nonce satisfies the JWS "NonceSource" interface by using a nonce stored by
+// the client from previous responses. That nonce value will be returned after
+// first getting a replacement nonce to store from the ACME server's NewNonce
+// endpoint. This ensures a constant supply of fresh nonces by always fetching
+// a replacement at the same time we use the old nonce.
+func (c *Client) Nonce() (string, error) {
+	n := c.nonce
+	err := c.RefreshNonce()
+	if err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// RefreshNonce fetches a new nonce from the ACME server's NewNonce endpoint and
+// stores it in the client's memory to be used in subsequent Nonce calls.
+func (c *Client) RefreshNonce() error {
+	nonceURL, ok := c.GetEndpointURL(acme.NEW_NONCE_ENDPOINT)
+	if !ok {
+		return fmt.Errorf(
+			"Missing %q entry in ACME server directory", acme.NEW_NONCE_ENDPOINT)
+	}
+
+	resp, err := c.net.HeadURL(nonceURL)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("%q returned HTTP status %d, expected %d\n",
+			acme.NEW_NONCE_ENDPOINT, resp.StatusCode, http.StatusOK)
+	}
+
+	nonce := resp.Header.Get(acme.REPLAY_NONCE_HEADER)
+	if nonce == "" {
+		return fmt.Errorf("%q returned no %q header value",
+			acme.NEW_NONCE_ENDPOINT, acme.REPLAY_NONCE_HEADER)
+	}
+
+	if nonce == c.nonce {
+		return fmt.Errorf("%q returned the nonce %q more than once",
+			acme.NEW_NONCE_ENDPOINT, acme.REPLAY_NONCE_HEADER)
+	}
+
+	c.nonce = nonce
+	log.Printf("Updated nonce to %q", nonce)
+	return nil
+}

--- a/acme/client/resources.go
+++ b/acme/client/resources.go
@@ -1,0 +1,304 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/cpu/acmeshell/acme"
+	"github.com/cpu/acmeshell/acme/resources"
+	"github.com/cpu/acmeshell/net"
+)
+
+// CreateAccount creates the given Account resource with the ACME server.
+// The Account is updated with the ID returned in the server's response's
+// Location header if the operation is successful, otherwise an error is
+// returned.
+//
+// Important: This function always unconditionally agrees to the server's terms
+// of service (e.g. it sends "termsOfServiceAgreed:"true" in all account
+// creation requests). This is one of MANY reasons why you should not be using
+// ACME Shell for anything except development and testing!
+//
+// See
+// https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.3
+// for more information on account creation.
+func (c *Client) CreateAccount(acct *resources.Account) error {
+	if c.nonce == "" {
+		if err := c.RefreshNonce(); err != nil {
+			return err
+		}
+	}
+	if acct.ID != "" {
+		return fmt.Errorf(
+			"create: account already exists under ID %q\n", acct.ID)
+	}
+
+	newAcctReq := struct {
+		Contact   []string `json:",omitempty"`
+		ToSAgreed bool     `json:"termsOfServiceAgreed"`
+	}{
+		Contact:   acct.Contact,
+		ToSAgreed: true,
+	}
+
+	reqBody, err := json.Marshal(&newAcctReq)
+	if err != nil {
+		return err
+	}
+
+	newAcctURL, ok := c.GetEndpointURL(acme.NEW_ACCOUNT_ENDPOINT)
+	if !ok {
+		return fmt.Errorf(
+			"create: ACME server missing %q endpoint in directory",
+			acme.NEW_ACCOUNT_ENDPOINT)
+	}
+
+	signResult, err := c.Sign(
+		newAcctURL,
+		reqBody,
+		&SigningOptions{
+			EmbedKey: true,
+			Key:      acct.PrivateKey,
+		})
+	if err != nil {
+		return fmt.Errorf("create: %s\n", err)
+	}
+
+	log.Printf("Sending %q request (contact: %s) to %q",
+		acme.NEW_ACCOUNT_ENDPOINT, acct.Contact, newAcctURL)
+	resp, err := c.PostURL(newAcctURL, signResult.SerializedJWS)
+	if err != nil {
+		return err
+	}
+
+	respOb := resp.Response
+	if respOb.StatusCode != http.StatusCreated {
+		return fmt.Errorf("create: server returned status code %d, expected %d",
+			respOb.StatusCode, http.StatusCreated)
+	}
+
+	locHeader := respOb.Header.Get("Location")
+	if locHeader == "" {
+		return fmt.Errorf("create: server returned response with no Location header")
+	}
+
+	// Store the Location header as the Account's ID
+	acct.ID = locHeader
+	log.Printf("Created account with ID %q\n", acct.ID)
+	return nil
+}
+
+// CreateOrder creates the given Order resource with the ACME server. If the
+// operation is successful the Order's ID field is populated with the value of
+// the server's reply's Location header. Otherwise a non-nil error is returned.
+//
+// For more information on Order creation see "Applying for Certificate
+// Issuance" in the ACME specification:
+// https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.4
+func (c *Client) CreateOrder(order *resources.Order) error {
+	if c.nonce == "" {
+		if err := c.RefreshNonce(); err != nil {
+			return err
+		}
+	}
+	if c.ActiveAccountID() == "" {
+		return fmt.Errorf("createOrder: active account is nil or has not been created")
+	}
+
+	req := struct {
+		Identifiers []resources.Identifier
+	}{
+		Identifiers: order.Identifiers,
+	}
+
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	newOrderURL, ok := c.GetEndpointURL(acme.NEW_ORDER_ENDPOINT)
+	if !ok {
+		return fmt.Errorf(
+			"createOrder: ACME server missing %q endpoint in directory",
+			acme.NEW_ORDER_ENDPOINT)
+	}
+
+	// Sign the new order request with the active account
+	signResult, err := c.Sign(newOrderURL, reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("createOrder: %s\n", err)
+	}
+
+	resp, err := c.PostURL(newOrderURL, signResult.SerializedJWS)
+	if err != nil {
+		return err
+	}
+
+	respOb := resp.Response
+	if respOb.StatusCode != http.StatusCreated {
+		return fmt.Errorf("createOrder: server returned status code %d, expected %d",
+			respOb.StatusCode, http.StatusCreated)
+	}
+
+	locHeader := respOb.Header.Get("Location")
+	if locHeader == "" {
+		return fmt.Errorf("create: server returned response with no Location header")
+	}
+
+	// Unmarshal the updated order
+	err = json.Unmarshal(resp.RespBody, &order)
+	if err != nil {
+		return fmt.Errorf("create: server returned invalid JSON: %s", err)
+	}
+
+	// Store the Location header as the Order's ID
+	order.ID = locHeader
+	log.Printf("Created new order with ID %q\n", order.ID)
+	// Save the order for the account
+	c.ActiveAccount.Orders = append(c.ActiveAccount.Orders, order.ID)
+	return nil
+}
+
+// UpdateOrder refreshes a given Order by fetching its ID URL from the ACME
+// server. If this is successful the Order is mutated in place. Otherwise a nil
+// Order and a non-nil error are returned.
+//
+// Calling UpdateOrder is required to refresh an Order's Status field to
+// synchronize the resource with the server-side representation.
+func (c *Client) UpdateOrder(order *resources.Order) error {
+	if order == nil {
+		return fmt.Errorf("updateOrder: order must not be nil")
+	}
+	if order.ID == "" {
+		return fmt.Errorf("updateOrder: order must have an ID")
+	}
+
+	var resp *net.NetResponse
+	var err error
+	if c.PostAsGet {
+		resp, err = c.PostAsGetURL(order.ID)
+	} else {
+		resp, err = c.GetURL(order.ID)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(resp.RespBody, &order)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateAuthz refreshes a given Authz by fetching its ID URL from the ACME
+// server. If this is successful the Authz is updated in place. Otherwise an
+// error is returned.
+//
+// Calling UpdateAuthz is required to refresh an Authz's Status field to
+// synchronize the resource with the server-side representation.
+func (c *Client) UpdateAuthz(authz *resources.Authorization) error {
+	if authz == nil {
+		return fmt.Errorf("UpdateAuthz: authz must not be nil")
+	}
+	if authz.ID == "" {
+		return fmt.Errorf("UpdateAuthz: authz must have an ID")
+	}
+
+	var resp *net.NetResponse
+	var err error
+	if c.PostAsGet {
+		resp, err = c.PostAsGetURL(authz.ID)
+	} else {
+		resp, err = c.GetURL(authz.ID)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(resp.RespBody, &authz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateChallenge refreshes a given Challenge by fetching its URL from the ACME
+// server. If this is successful the Challenge is updated in place. Otherwise an
+// error is returned.
+func (c *Client) UpdateChallenge(chall *resources.Challenge) error {
+	if chall == nil {
+		return fmt.Errorf("UpdateChallenge: chall must not be nil")
+	}
+	if chall.URL == "" {
+		return fmt.Errorf("UpdateChallenge: chall must have a URL")
+	}
+
+	var resp *net.NetResponse
+	var err error
+	if c.PostAsGet {
+		resp, err = c.PostAsGetURL(chall.URL)
+	} else {
+		resp, err = c.GetURL(chall.URL)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(resp.RespBody, &chall)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) OrderByIndex(index int) (*resources.Order, error) {
+	if c.ActiveAccountID() == "" {
+		return nil, errors.New(
+			"OrderByIndex: active account is nil or has not been created")
+	}
+
+	// Find the Order URL
+	orderURL, err := c.ActiveAccount.OrderURL(index)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the full Order object
+	order := &resources.Order{ID: orderURL}
+	if err := c.UpdateOrder(order); err != nil {
+		return nil, err
+	}
+	return order, nil
+}
+
+func (c *Client) AuthzByIdentifier(order *resources.Order, identifier string) (*resources.Authorization, error) {
+	if order == nil {
+		return nil, errors.New("AuthzByIdentifier: Order was nil")
+	}
+	if len(order.Authorizations) == 0 {
+		return nil, errors.New("AuthzByIdentifier: Order has no authorizations")
+	}
+
+	// Loop through the order's authoriation URLs, fetching the authz object for
+	// each. Stop when an authz with the requested identifier is found.
+	for _, authzURL := range order.Authorizations {
+		authz := &resources.Authorization{ID: authzURL}
+		if err := c.UpdateAuthz(authz); err != nil {
+			return nil, err
+		}
+		if authz.Identifier.Value == identifier {
+			return authz, nil
+		}
+	}
+	return nil, fmt.Errorf(
+		"AuthzByIdentifier: Order %q has no authz with identifier %q",
+		order.ID,
+		identifier)
+}

--- a/cmd/acmeshell/main.go
+++ b/cmd/acmeshell/main.go
@@ -95,6 +95,11 @@ func main() {
 		"",
 		"Read commands from the specified file instead of stdin")
 
+	postAsGet := flag.Bool(
+		"postAsGet",
+		false,
+		"Use POST-as-GET requests instead of GET requests (requires Pebble -strict or equiv)")
+
 	flag.Parse()
 
 	if *pebble {
@@ -113,7 +118,6 @@ func main() {
 		err = syscall.Dup2(int(f.Fd()), 0)
 		acmecmd.FailOnError(err, fmt.Sprintf(
 			"Error duplicating stdin fd: %v", err))
-		fmt.Printf("Replaced stdin with file\n")
 	}
 
 	config := &acmeshell.ACMEShellOptions{
@@ -123,6 +127,7 @@ func main() {
 			ContactEmail: *email,
 			AccountPath:  *acctPath,
 			AutoRegister: *autoRegister,
+			POSTAsGET:    *postAsGet,
 			InitialOutput: acmeclient.OutputOptions{
 				PrintRequests:   *printRequests,
 				PrintResponses:  *printResponses,

--- a/shell/commands/getCert/getCert.go
+++ b/shell/commands/getCert/getCert.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/cpu/acmeshell/acme/resources"
+	"github.com/cpu/acmeshell/net"
 	"github.com/cpu/acmeshell/shell/commands"
 )
 
@@ -83,7 +84,12 @@ func getCertHandler(c *ishell.Context, leftovers []string) {
 		return
 	}
 
-	resp, err := client.GetURL(order.Certificate)
+	var resp *net.NetResponse
+	if client.PostAsGet {
+		resp, err = client.PostAsGetURL(order.Certificate)
+	} else {
+		resp, err = client.GetURL(order.Certificate)
+	}
 	if err != nil {
 		c.Printf("getCert: failed to GET order certificate URL %q : %v\n", order.Certificate, err)
 		return


### PR DESCRIPTION
You can now use `acmeshell -postAsGet` with `pebble -strict` and all GETs to resources will be handled as POST-as-GET requests instead.

Also split up the `client/client.go` file into multiple `.go` files in the `client` package to help keep things manageable. 