### PR TITLE
Small fixes and tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,8 @@ _testmain.go
 *.test
 *.prof
 
+# Generated website content
 website/public
+
+# Default -account file for acmeshell
+acmeshell.account.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ install:
 
 before_script:
   # Start Pebble with the correct env & arguments for our tests
-  - PEBBLE_WFE_NONCEREJECT=0 pebble -dnsserver 127.0.0.1:5252 &
+  - PEBBLE_WFE_NONCEREJECT=0 pebble -strict -dnsserver 127.0.0.1:5252 &
   # Wait for Pebble to become available before proceeding
   - until </dev/tcp/localhost/14000 ; do sleep 0.1 ; done
 
 script:
   - go test -v -mod=vendor ./...
   - go install -v -mod=vendor ./...
-  - acmeshell -pebble -in docs/example.script.txt
+  - acmeshell -pebble -postAsGet -in docs/example.script.txt

--- a/acme/client/client.go
+++ b/acme/client/client.go
@@ -96,15 +96,15 @@ type OutputOptions struct {
 // https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.1.1
 // for more information about the ACME directory resource.
 //
-// The CACert field is a string containing a file path to a file containing one
-// or more PEM encoded CA certificate that should be used as trust roots for
-// HTTPS requests to the ACME server. This field is mandatory and must not be
-// empty. For instance, if you are using Pebble as the ACME server, it should be
-// the file path to the "test/certs/pebble.minica.pem" file from the Pebble
-// source directory. If you are using a public ACME server with a trusted HTTPS
-// certificate you should provide the path to a file containing the
-// combination of all of the PEM encoded system trusted root CA certificates.
-// Often this is something like "/etc/ssl/certs.pem".
+// The CACert field is an optional string containing a file path to a file
+// containing one or more PEM encoded CA certificate that should be used as
+// trust roots for HTTPS requests to the ACME server. If empty the default
+// system roots are used.  For example, if you are using Pebble as the ACME
+// server, it should be the file path to the "test/certs/pebble.minica.pem" file
+// from the Pebble source directory. If you are using a public ACME server with
+// a trusted HTTPS certificate you should provide the path to a file containing
+// the combination of all of the PEM encoded system trusted root CA
+// certificates.  Often this is something like "/etc/ssl/certs.pem".
 //
 // The ContactEmail field is a string expected to contain a single email
 // address or to be empty. It will be used as a "mailto://" contact address when
@@ -123,8 +123,8 @@ type ClientConfig struct {
 	// A fully qualified URL for the ACME server's directory resource. Must
 	// include an HTTP/HTTPS protocol prefix.
 	DirectoryURL string
-	// A file path to one or more PEM encoded CA certificates to be used as trust
-	// roots for HTTPS requests to the ACME server.
+	// An optional file path to one or more PEM encoded CA certificates to be used
+	// as trust roots for HTTPS requests to the ACME server.
 	CACert string
 	// An optional email address to use if AutoRegister is true and an Account is
 	// created with the ACME server. It should not have a protocol prefix,
@@ -186,9 +186,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 	}
 
 	// Create the ACME net client
-	net, err := acmenet.New(acmenet.Config{
-		CABundlePath: config.CACert,
-	})
+	net, err := acmenet.New(config.CACert)
 	cmd.FailOnError(err, "Unable to create ACME net client")
 
 	// NOTE(@cpu): Its safe to throw away the returned err here because we check

--- a/acme/client/nonce.go
+++ b/acme/client/nonce.go
@@ -36,7 +36,7 @@ func (c *Client) RefreshNonce() error {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%q returned HTTP status %d, expected %d\n",
 			acme.NEW_NONCE_ENDPOINT, resp.StatusCode, http.StatusOK)
 	}

--- a/acme/resources/account.go
+++ b/acme/resources/account.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 )
 
 // Account holds information related to a single ACME Account resource. If the

--- a/acme/resources/account.go
+++ b/acme/resources/account.go
@@ -117,8 +117,9 @@ func SaveAccount(path string, account *Account) error {
 	if err != nil {
 		return err
 	}
-	// write the serialized data to the provided filepath
-	return ioutil.WriteFile(path, frozenBytes, os.ModePerm)
+	// write the serialized data to the provided filepath using a mode that only
+	// allows access to the current user. This file contains a private key!
+	return ioutil.WriteFile(path, frozenBytes, 0600)
 }
 
 type rawAccount struct {

--- a/acme/resources/challenge.go
+++ b/acme/resources/challenge.go
@@ -25,6 +25,8 @@ type Challenge struct {
 	Token string
 	// The Status of the challenge.
 	Status string
+	// The Error associated with an invalid challenge
+	Error *Problem `json:",omitempty"`
 }
 
 // String returns the URL of the Challenge.

--- a/acme/resources/order.go
+++ b/acme/resources/order.go
@@ -13,6 +13,8 @@ type Order struct {
 	ID string
 	// The Status of the Order.
 	Status string
+	// The Error associated with an invalid order
+	Error *Problem `json:",omitempty"`
 	// The Identifiers the Order wishes to finalize a Certificate for once the
 	// Order is ready.
 	Identifiers []Identifier

--- a/acme/resources/problem.go
+++ b/acme/resources/problem.go
@@ -1,0 +1,8 @@
+package resources
+
+// Problem is a struct representing a problem document from the server.
+type Problem struct {
+	Type   string
+	Detail string
+	Status int
+}

--- a/cmd/acmeshell/main.go
+++ b/cmd/acmeshell/main.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	DIRECTORY_DEFAULT    = "https://acme-staging-v02.api.letsencrypt.org/directory"
-	CA_DEFAULT           = "/etc/ssl/cert.pem"
 	AUTOREGISTER_DEFAULT = true
 	CONTACT_DEFAULT      = ""
 	ACCOUNT_DEFAULT      = ""
@@ -32,7 +31,7 @@ func main() {
 
 	caCert := flag.String(
 		"ca",
-		CA_DEFAULT,
+		"",
 		"CA certificate(s) for verifying ACME server HTTPS")
 
 	autoRegister := flag.Bool(

--- a/cmd/acmeshell/main.go
+++ b/cmd/acmeshell/main.go
@@ -17,7 +17,7 @@ const (
 	DIRECTORY_DEFAULT    = "https://acme-staging-v02.api.letsencrypt.org/directory"
 	AUTOREGISTER_DEFAULT = true
 	CONTACT_DEFAULT      = ""
-	ACCOUNT_DEFAULT      = ""
+	ACCOUNT_DEFAULT      = "acmeshell.account.json"
 	HTTP_PORT_DEFAULT    = 5002
 	TLS_PORT_DEFAULT     = 5001
 	DNS_PORT_DEFAULT     = 5252
@@ -47,7 +47,7 @@ func main() {
 	acctPath := flag.String(
 		"account",
 		ACCOUNT_DEFAULT,
-		"Optional JSON filepath to save/restore auto-registered ACME account to")
+		"Optional JSON filepath to use to save/restore auto-registered ACME account")
 
 	httpPort := flag.Int(
 		"httpPort",

--- a/shell/acmeshell.go
+++ b/shell/acmeshell.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/cpu/acmeshell/shell/commands/poll"
 	_ "github.com/cpu/acmeshell/shell/commands/post"
 	_ "github.com/cpu/acmeshell/shell/commands/rollover"
+	_ "github.com/cpu/acmeshell/shell/commands/saveAccount"
 	_ "github.com/cpu/acmeshell/shell/commands/sign"
 	_ "github.com/cpu/acmeshell/shell/commands/solve"
 	_ "github.com/cpu/acmeshell/shell/commands/switchAccount"

--- a/shell/commands/saveAccount/saveAccount.go
+++ b/shell/commands/saveAccount/saveAccount.go
@@ -1,0 +1,70 @@
+package saveAccount
+
+import (
+	"flag"
+
+	"github.com/abiosoft/ishell"
+	"github.com/cpu/acmeshell/acme/resources"
+	"github.com/cpu/acmeshell/shell/commands"
+)
+
+type saveAccountOptions struct {
+	jsonPath string
+}
+
+var (
+	opts = saveAccountOptions{}
+)
+
+func init() {
+	registerSaveAccountCmd()
+}
+
+func registerSaveAccountCmd() {
+	saveAccountFlags := flag.NewFlagSet("saveAccount", flag.ContinueOnError)
+	saveAccountFlags.StringVar(&opts.jsonPath, "json", "", "Filepath to a JSON save file for the account. If empty the -account argument is used")
+
+	commands.RegisterCommand(
+		&ishell.Cmd{
+			Name:     "saveAccount",
+			Aliases:  []string{"save", "saveReg", "saveRegistration"},
+			Help:     "Save the active ACME account",
+			LongHelp: `TODO(@cpu): Write this!`,
+		},
+		nil,
+		saveAccountHandler,
+		saveAccountFlags)
+}
+
+func saveAccountHandler(c *ishell.Context, leftovers []string) {
+	defer func() {
+		opts = saveAccountOptions{
+			jsonPath: "",
+		}
+	}()
+
+	client := commands.GetClient(c)
+
+	acct := client.ActiveAccount
+	if acct == nil {
+		c.Printf("no active account to save")
+		return
+	}
+
+	jsonPath := acct.Path()
+	if opts.jsonPath != "" {
+		jsonPath = opts.jsonPath
+	}
+
+	if jsonPath == "" {
+		c.Printf("no -json path provided and active account has no default path.")
+		return
+	}
+
+	if err := resources.SaveAccount(jsonPath, acct); err != nil {
+		c.Printf("error saving account to %q : %v\n", jsonPath, err)
+		return
+	}
+
+	c.Printf("Saved active account data to %q\n", jsonPath)
+}


### PR DESCRIPTION
- client: fix expected nonce http code
- acmeshell: remove default CA bundle
- acmeshell: save/load account by default
- resources: fix mode on account json files
- resources: Add error field to chall/order
- resources: fix goimports for account.go
- shell: add save command, persist acct order URLs