### PR TITLE
acmeshell: improve -pebble

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,11 @@ server's HTTPS certificate with the `-ca` flag.
 
 #### Pebble Defaults
 
-If you specify `-pebble` then [Pebble][pebble] defaults are assumed and the
+If you specify `-pebble` then ACMEShell assumes [Pebble][pebble] defaults. The
 `-directory` address will be `https://localhost:14000/dir` to match the Pebble
-default and the `-ca` flag will be
-`$GOPATH/src/github.com/letsencrypt/pebble/test/certs/pebble.minica.pem`. If you
-do not have Pebble installed in your `$GOPATH` you may need to download the
-`pebble.minica.pem` file from the Pebble repo and specify its location with the
-`-ca` flag.
+default and the `-ca` flag will be configured with the default Pebble HTTPS CA.
+The ACMEShell will also be configured to use the default `pebble-challtestsrv`
+address `http://localhost:8055` as the `-challSrv` argument.
 
 #### Legacy GET requests
 

--- a/cmd/acmeshell/main.go
+++ b/cmd/acmeshell/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	acmeclient "github.com/cpu/acmeshell/acme/client"
@@ -21,6 +22,32 @@ const (
 	TLS_PORT_DEFAULT     = 5001
 	DNS_PORT_DEFAULT     = 5252
 	CHALLSRV_DEFAULT     = ""
+
+	// PEBBLE_CA_DEFAULT is an embedded const version of
+	// github.com/letsencrypt/pebble/test/certs/pebble.minica.pem
+	// The -pebble command line flag will write this .pem to a tempfile to
+	// reference.
+	PEBBLE_CA_DEFAULT = `
+-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIIJOLbes8sTr4wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgMjRlMmRiMCAXDTE3MTIwNjE5NDIxMFoYDzIxMTcx
+MjA2MTk0MjEwWjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAyNGUyZGIwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5WgZNoVJandj43kkLyU50vzCZ
+alozvdRo3OFiKoDtmqKPNWRNO2hC9AUNxTDJco51Yc42u/WV3fPbbhSznTiOOVtn
+Ajm6iq4I5nZYltGGZetGDOQWr78y2gWY+SG078MuOO2hyDIiKtVc3xiXYA+8Hluu
+9F8KbqSS1h55yxZ9b87eKR+B0zu2ahzBCIHKmKWgc6N13l7aDxxY3D6uq8gtJRU0
+toumyLbdzGcupVvjbjDP11nl07RESDWBLG1/g3ktJvqIa4BWgU2HMh4rND6y8OD3
+Hy3H8MY6CElL+MOCbFJjWqhtOxeFyZZV9q3kYnk9CAuQJKMEGuN4GU6tzhW1AgMB
+AAGjRTBDMA4GA1UdDwEB/wQEAwIChDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB
+BQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAQEAF85v
+d40HK1ouDAtWeO1PbnWfGEmC5Xa478s9ddOd9Clvp2McYzNlAFfM7kdcj6xeiNhF
+WPIfaGAi/QdURSL/6C1KsVDqlFBlTs9zYfh2g0UXGvJtj1maeih7zxFLvet+fqll
+xseM4P9EVJaQxwuK/F78YBt0tCNfivC6JNZMgxKF59h0FBpH70ytUSHXdz7FKwix
+Mfn3qEb9BXSk0Q3prNV5sOV3vgjEtB4THfDxSz9z3+DepVnW3vbbqwEbkXdk3j82
+2muVldgOUgTwK8eT+XdofVdntzU/kzygSAtAQwLJfn51fS1GvEcYGBc1bDryIqmF
+p9BI7gVKtWSZYegicA==
+-----END CERTIFICATE-----
+`
 )
 
 func main() {
@@ -112,11 +139,21 @@ func main() {
 	flag.Parse()
 
 	if *pebble {
+		tmpFile, err := ioutil.TempFile("", "pebble.ca.*.pem")
+		acmecmd.FailOnError(err, fmt.Sprintf("Error opening pebble CA temp file: %v", err))
+		defer os.Remove(tmpFile.Name())
+
+		_, err = tmpFile.Write([]byte(PEBBLE_CA_DEFAULT))
+		acmecmd.FailOnError(err, fmt.Sprintf("Error writing pebble CA temp file: %v", err))
+
+		pebbleCA := tmpFile.Name()
+
+		err = tmpFile.Close()
+		acmecmd.FailOnError(err, fmt.Sprintf("Error closing pebble CA temp file: %v", err))
+
 		pebbleDirectory := "https://localhost:14000/dir"
 		pebbleChallSrv := "http://localhost:8055"
 		directory = &pebbleDirectory
-		pebbleBaseDir := os.Getenv("GOPATH")
-		pebbleCA := pebbleBaseDir + "/src/github.com/letsencrypt/pebble/test/certs/pebble.minica.pem"
 		caCert = &pebbleCA
 		challSrv = &pebbleChallSrv
 	}

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -1,7 +1,7 @@
 ---
 title: "About"
 type: "homepage"
-date: 2019-11-24T00:00:00-00:00
+date: 2019-12-01T00:00:00-00:00
 ---
 
 An interactive shell designed for [RFC 8555][acme] ACME client/server
@@ -172,13 +172,11 @@ server's HTTPS certificate with the `-ca` flag.
 
 #### Pebble Defaults
 
-If you specify `-pebble` then [Pebble][pebble] defaults are assumed and the
+If you specify `-pebble` then ACMEShell assumes [Pebble][pebble] defaults. The
 `-directory` address will be `https://localhost:14000/dir` to match the Pebble
-default and the `-ca` flag will be
-`$GOPATH/src/github.com/letsencrypt/pebble/test/certs/pebble.minica.pem`. If you
-do not have Pebble installed in your `$GOPATH` you may need to download the
-`pebble.minica.pem` file from the Pebble repo and specify its location with the
-`-ca` flag.
+default and the `-ca` flag will be configured with the default Pebble HTTPS CA.
+The ACMEShell will also be configured to use the default `pebble-challtestsrv`
+address `http://localhost:8055` as the `-challSrv` argument.
 
 #### Legacy GET requests
 
@@ -400,6 +398,8 @@ While not a complete list (see "help") the most common high-level commands are:
 * **poll** - poll a resource until it's in a specific state.
 * **finalize** - finalize an order by POSTing a CSR.
 * **getCert** - get an order's certificate resource.
+* **deactivateAuthz** - deactivate an authorization.
+* **deactivateAccount** - deactivate an account.
 
 Here's an example of using the high level commands non-interactively to complete
 an order issuance:
@@ -499,7 +499,6 @@ ACMEShell supports some handy tricks that may be useful to you:
 
 * Support RSA account keys (lol).
 * `revoke` high level command for revocation.
-* high level command to deactivate authorizations
 * RFC 8555 subproblem support
 * support for exiting on a command failure (e.g. for integration tests).
 * so much cleanup...


### PR DESCRIPTION
It shouldn't rely on a $GOPATH clone of Pebble to get the default WFE CA.