### PR TITLE
Improve newOrder to parse and print all fields

### DIFF
--- a/acme/client/resources.go
+++ b/acme/client/resources.go
@@ -154,8 +154,8 @@ func (c *Client) Rollover(newKey crypto.Signer) error {
 }
 
 // CreateOrder creates the given Order resource with the ACME server. If the
-// operation is successful the Order's ID field is populated with the value of
-// the server's reply's Location header. Otherwise a non-nil error is returned.
+// operation is successful, the order is mutated in place with the response
+// from the server's reply. Otherwise a non-nil error is returned.
 //
 // For more information on Order creation see "Applying for Certificate
 // Issuance" in RFC 8555:

--- a/acme/resources/order.go
+++ b/acme/resources/order.go
@@ -13,8 +13,14 @@ type Order struct {
 	ID string
 	// The Status of the Order.
 	Status string
+	// The timestamp after which the server will consider this order invalid.
+	Expires string
 	// The Error associated with an invalid order
 	Error *Problem `json:",omitempty"`
+	// NotBefore and NotAfter are the requested values of the notBefore and
+	// notAfter fields of the resulting certificate. Ignored by Boulder.
+	NotBefore string
+	NotAfter  string
 	// The Identifiers the Order wishes to finalize a Certificate for once the
 	// Order is ready.
 	Identifiers []Identifier

--- a/shell/commands/newOrder/newOrder.go
+++ b/shell/commands/newOrder/newOrder.go
@@ -82,4 +82,11 @@ func createOrder(c *ishell.Context, fqdns []string) {
 		c.Printf("newOrder: error creating new order with ACME server: %s\n", err)
 		return
 	}
+
+	orderStr, err := commands.PrintJSON(order)
+	if err != nil {
+		c.Printf("getOrder: error serializing order: %v\n", err)
+		return
+	}
+	c.Printf("%s\n", orderStr)
 }


### PR DESCRIPTION
This change adds three new fields to the internal representation of
orders (`expires`, `notBefore`, and `notAfter`), for full compliance
with the set of fields defined by RFC 8555 7.1.3:
  https://tools.ietf.org/html/rfc8555#section-7.1.3

In addition, it adds logic to print the full result of creating a
new order, rather than only printing the URL of the order object.
Finally, it updates the documentation of the `client.CreateOrder`
method to clarify that the given order object is modified in place.